### PR TITLE
Implement login/signup authentication with server-side sessions

### DIFF
--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -1,0 +1,13 @@
+"use server"
+
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { sessionCookieName } from "@/lib/session"
+
+export async function logout() {
+  const cookieStore = await cookies()
+  cookieStore.delete(sessionCookieName)
+
+  redirect("/login")
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,9 +1,37 @@
-export default function DashboardPage() {
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { readUserIdFromSessionCookie, sessionCookieName } from "@/lib/session"
+
+import { logout } from "./actions"
+
+export default async function DashboardPage() {
+  const cookieStore = await cookies()
+  const sessionValue = cookieStore.get(sessionCookieName)?.value
+  const userId = readUserIdFromSessionCookie(sessionValue)
+
+  if (!userId) {
+    redirect("/login")
+  }
+
   return (
     <main className="min-h-screen bg-gray-50 p-6">
       <div className="mx-auto max-w-5xl">
-        <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
-        <p className="mt-2 text-gray-600">単語帳や学習状況をここに表示します。</p>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
+            <p className="mt-2 text-gray-600">単語帳や学習状況をここに表示します。</p>
+          </div>
+
+          <form action={logout}>
+            <button
+              type="submit"
+              className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            >
+              ログアウト
+            </button>
+          </form>
+        </div>
 
         <section className="mt-8 grid gap-4 md:grid-cols-3">
           <div className="rounded-2xl bg-white p-6 shadow">

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,40 @@
+"use server"
+
+import { compare } from "bcrypt"
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { prisma } from "@/lib/prisma"
+import { createSessionCookie, sessionCookieName } from "@/lib/session"
+
+export async function login(formData: FormData) {
+  const email = String(formData.get("email") ?? "").trim()
+  const password = String(formData.get("password") ?? "")
+
+  if (!email || !password) {
+    redirect("/login?error=メールアドレスとパスワードは必須です")
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } })
+
+  if (!user) {
+    redirect("/login?error=メールアドレスまたはパスワードが正しくありません")
+  }
+
+  const valid = await compare(password, user.password)
+
+  if (!valid) {
+    redirect("/login?error=メールアドレスまたはパスワードが正しくありません")
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.set(sessionCookieName, createSessionCookie(user.id), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  })
+
+  redirect("/dashboard")
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,13 +1,26 @@
-export default function LoginPage() {
+import Link from "next/link"
+
+import { login } from "./actions"
+
+type LoginPageProps = {
+  searchParams?: Promise<{ error?: string }>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const params = (await searchParams) ?? {}
+  const errorMessage = params.error
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow">
         <h1 className="text-2xl font-bold text-gray-900">ログイン</h1>
-        <p className="mt-2 text-sm text-gray-600">
-          アカウントにログインしてください
-        </p>
+        <p className="mt-2 text-sm text-gray-600">アカウントにログインしてください</p>
 
-        <form className="mt-6 space-y-4">
+        {errorMessage ? (
+          <p className="mt-4 rounded-lg bg-red-50 px-4 py-2 text-sm text-red-700">{errorMessage}</p>
+        ) : null}
+
+        <form action={login} className="mt-6 space-y-4">
           <div>
             <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
               メールアドレス
@@ -16,6 +29,7 @@ export default function LoginPage() {
               id="email"
               name="email"
               type="email"
+              required
               className="w-full rounded-lg border border-gray-300 px-4 py-2 outline-none focus:border-gray-900"
               placeholder="you@example.com"
             />
@@ -29,6 +43,7 @@ export default function LoginPage() {
               id="password"
               name="password"
               type="password"
+              required
               className="w-full rounded-lg border border-gray-300 px-4 py-2 outline-none focus:border-gray-900"
               placeholder="••••••••"
             />
@@ -44,9 +59,9 @@ export default function LoginPage() {
 
         <p className="mt-6 text-sm text-gray-600">
           アカウントをお持ちでないですか？{" "}
-          <a href="/signup" className="font-medium text-gray-900 underline">
+          <Link href="/signup" className="font-medium text-gray-900 underline">
             新規登録
-          </a>
+          </Link>
         </p>
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,27 @@
-import Image from "next/image";
+import Link from "next/link"
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+    <main className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-xl rounded-2xl bg-white p-8 shadow">
+        <h1 className="text-3xl font-bold text-gray-900">Memorizar</h1>
+        <p className="mt-3 text-gray-600">単語学習アプリへようこそ。ログインして学習を開始しましょう。</p>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/login"
+            className="rounded-lg bg-gray-900 px-5 py-3 text-center font-medium text-white hover:bg-gray-800"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+            ログイン
+          </Link>
+          <Link
+            href="/signup"
+            className="rounded-lg border border-gray-300 bg-white px-5 py-3 text-center font-medium text-gray-700 hover:bg-gray-100"
           >
-            Documentation
-          </a>
+            新規登録
+          </Link>
         </div>
-      </main>
-    </div>
-  );
+      </div>
+    </main>
+  )
 }

--- a/src/app/signup/actions.ts
+++ b/src/app/signup/actions.ts
@@ -1,0 +1,48 @@
+"use server"
+
+import { hash } from "bcrypt"
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { prisma } from "@/lib/prisma"
+import { createSessionCookie, sessionCookieName } from "@/lib/session"
+
+export async function signup(formData: FormData) {
+  const name = String(formData.get("name") ?? "").trim()
+  const email = String(formData.get("email") ?? "").trim()
+  const password = String(formData.get("password") ?? "")
+
+  if (!email || !password) {
+    redirect("/signup?error=メールアドレスとパスワードは必須です")
+  }
+
+  if (password.length < 8) {
+    redirect("/signup?error=パスワードは8文字以上で入力してください")
+  }
+
+  const existingUser = await prisma.user.findUnique({ where: { email } })
+
+  if (existingUser) {
+    redirect("/signup?error=このメールアドレスはすでに使用されています")
+  }
+
+  const hashedPassword = await hash(password, 10)
+  const user = await prisma.user.create({
+    data: {
+      name: name || null,
+      email,
+      password: hashedPassword,
+    },
+  })
+
+  const cookieStore = await cookies()
+  cookieStore.set(sessionCookieName, createSessionCookie(user.id), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  })
+
+  redirect("/dashboard")
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,13 +1,26 @@
-export default function SignupPage() {
+import Link from "next/link"
+
+import { signup } from "./actions"
+
+type SignupPageProps = {
+  searchParams?: Promise<{ error?: string }>
+}
+
+export default async function SignupPage({ searchParams }: SignupPageProps) {
+  const params = (await searchParams) ?? {}
+  const errorMessage = params.error
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow">
         <h1 className="text-2xl font-bold text-gray-900">新規登録</h1>
-        <p className="mt-2 text-sm text-gray-600">
-          アカウントを作成してください
-        </p>
+        <p className="mt-2 text-sm text-gray-600">アカウントを作成してください</p>
 
-        <form className="mt-6 space-y-4">
+        {errorMessage ? (
+          <p className="mt-4 rounded-lg bg-red-50 px-4 py-2 text-sm text-red-700">{errorMessage}</p>
+        ) : null}
+
+        <form action={signup} className="mt-6 space-y-4">
           <div>
             <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
               名前
@@ -29,6 +42,7 @@ export default function SignupPage() {
               id="email"
               name="email"
               type="email"
+              required
               className="w-full rounded-lg border border-gray-300 px-4 py-2 outline-none focus:border-gray-900"
               placeholder="you@example.com"
             />
@@ -42,6 +56,8 @@ export default function SignupPage() {
               id="password"
               name="password"
               type="password"
+              required
+              minLength={8}
               className="w-full rounded-lg border border-gray-300 px-4 py-2 outline-none focus:border-gray-900"
               placeholder="8文字以上"
             />
@@ -57,9 +73,9 @@ export default function SignupPage() {
 
         <p className="mt-6 text-sm text-gray-600">
           すでにアカウントをお持ちですか？{" "}
-          <a href="/login" className="font-medium text-gray-900 underline">
+          <Link href="/login" className="font-medium text-gray-900 underline">
             ログイン
-          </a>
+          </Link>
         </p>
       </div>
     </main>

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client"
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient
+}
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+  })
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,53 @@
+import crypto from "node:crypto"
+
+const SESSION_COOKIE_NAME = "memorizar_session"
+const SESSION_SECRET = process.env.SESSION_SECRET ?? "memorizar-dev-secret"
+
+type SessionPayload = {
+  userId: number
+  exp: number
+}
+
+function sign(value: string) {
+  return crypto.createHmac("sha256", SESSION_SECRET).update(value).digest("base64url")
+}
+
+export function createSessionCookie(userId: number) {
+  const payload: SessionPayload = {
+    userId,
+    exp: Date.now() + 1000 * 60 * 60 * 24 * 7,
+  }
+
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url")
+  const signature = sign(encodedPayload)
+
+  return `${encodedPayload}.${signature}`
+}
+
+export function readUserIdFromSessionCookie(cookieValue?: string) {
+  if (!cookieValue) return null
+
+  const [payload, signature] = cookieValue.split(".")
+  if (!payload || !signature) return null
+
+  const expectedSignature = sign(payload)
+  const provided = Buffer.from(signature)
+  const expected = Buffer.from(expectedSignature)
+
+  if (provided.length !== expected.length) return null
+
+  if (!crypto.timingSafeEqual(provided, expected)) return null
+
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString()) as SessionPayload
+    if (!parsed.userId || parsed.exp < Date.now()) {
+      return null
+    }
+
+    return parsed.userId
+  } catch {
+    return null
+  }
+}
+
+export const sessionCookieName = SESSION_COOKIE_NAME


### PR DESCRIPTION
### Motivation
- Add a minimal, secure login/signup flow so users can register, authenticate, and access a protected `/dashboard` area.
- Use server-side actions and httpOnly signed cookies to avoid client-side token handling and to integrate with the existing Prisma schema.
- No external skill from `AGENTS.md` was required or used for this change.

### Description
- Add a signed session helper in `src/lib/session.ts` to create and validate an `memorizar_session` cookie with HMAC and expiry checks.
- Add a Prisma singleton client in `src/lib/prisma.ts` for safe reuse of `PrismaClient` across requests.
- Implement server actions `login`, `signup`, and `logout` in `src/app/login/actions.ts`, `src/app/signup/actions.ts`, and `src/app/dashboard/actions.ts` that use `bcrypt` and `prisma` and set/delete the signed httpOnly cookie.
- Wire pages to use the server actions and protect the dashboard by reading and validating the session cookie (`src/app/login/page.tsx`, `src/app/signup/page.tsx`, `src/app/dashboard/page.tsx`, `src/app/page.tsx`).

### Testing
- Attempted dependency install with `npm ci` / `npm install`, but the install did not complete cleanly in this environment so runtime deps (e.g. `next`) were not available and `next` binary was missing, causing `npm run dev` to fail with `next: not found`.
- Ran `npm run lint`, which failed due to incomplete/misaligned ESLint dependency resolution in the environment, so linting could not be validated.
- Attempted a browser smoke test with Playwright navigating to `/login`, which failed because the dev server could not be started (`ERR_EMPTY_RESPONSE`).
- No unit tests were added; manual validation steps are documented below for local verification: run `npm ci`, `npm run dev`, then exercise `/signup` → `/dashboard` → `logout` flows and inspect the `memorizar_session` cookie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b26c424e34832d8d8a92ad440665d7)